### PR TITLE
Support windows line endings in font parser

### DIFF
--- a/script/entities/font.js
+++ b/script/entities/font.js
@@ -7,7 +7,7 @@ let Font = {
         let characterList = {}
 
         try {
-            let lines = data.split('\n')
+            let lines = data.split(/\r\n?|\n/)
             let i = 0
             while (i < lines.length) {
                 let line = lines[i].toLowerCase()


### PR DESCRIPTION
At the moment the parser will report the character is too big because it treats `\r` as an extra column